### PR TITLE
(fix): hover on after

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -43,6 +43,21 @@ li {
     margin: 20px;
 }
 
+
+a:after {
+    content: "";
+    width: 0;
+    height: 2px;
+    margin: auto;
+    border-radius: 10px;
+    background: #fff;
+    position: absolute;
+    bottom: -6px;
+    left: 0;
+    right: 0;
+    transition: width .3s ease;
+}
+
 #home {
     position: relative;
 }


### PR DESCRIPTION
### Descrição

Seu ```:after``` precisa sair de um estado e ir para um outro estado para que a ```transition``` funcione.

Foi adicionado um pseudo-elemento com as mesmas características, porém com ```width: 0```, Ou seja, sairá de 0 e irá para 85px.
